### PR TITLE
refactor: clean up zsh aliases and update path exports

### DIFF
--- a/dot_Brewfile.tmpl
+++ b/dot_Brewfile.tmpl
@@ -37,8 +37,9 @@ brew "tfenv" # tfenvでterraformのバージョン管理をする
 tap "dashlane/tap"
 cask_args appdir: "/Applications"
 brew "mas" # ターミナルからApp Storeのアプリをインストールできるようにするやつ
-brew "pinentry-mac"
-brew "dashlane-cli"
+brew "pinentry-mac" # gpgのパスフレーズ入力用
+brew "dashlane-cli" # dashlaneのcli版。chezmoiで機密情報を埋め込むのに使う
+brew "kind" # kubernetes in docker
 
 ## caskを使うとMacのGUIアプリをインストールできる
 cask "slack"
@@ -62,7 +63,7 @@ cask "postman"
 cask "unity-hub"
 cask "zoom"
 cask "kindle"
-cask "wireshark"
+cask "wireshark-app"
 cask "spotify"
 cask "fl-studio"
 cask "font-Hack-nerd-font" # font ~ nerd-fontで検索するといろんなフォントがあるはず

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -5,14 +5,7 @@ source <(fzf --zsh)
 [ -f ~/.zplug.sh ] && source ~/.zplug.sh
 
 # alias
-alias yarn='corepack yarn'
-alias yarnpkg='corepack yarnpkg'
-alias pnpm='corepack pnpm'
-alias pnpx='corepack pnpx'
 alias gs="git branch | fzf | xargs git switch"
-
-export PATH="/Users/gotoharuka/.deno/bin:$PATH"
-export PATH="$(python3 -m site --user-base)/bin:$PATH"
 
 # 新しくコマンドをインストールしたときに自動的に認識させる
 zstyle ":completion:*:commands" rehash 1
@@ -80,17 +73,8 @@ bindkey "^r" fzf-history-widget
 # goのpath通す
 export PATH=$PATH:/usr/local/go/bin
 
-# pnpm
-export PNPM_HOME="/Users/gotoharuka/Library/pnpm"
-case ":$PATH:" in
-*":$PNPM_HOME:"*) ;;
-*) export PATH="$PNPM_HOME:$PATH" ;;
-esac
-# pnpm end
-
 # config asdf
-[ -f "$(brew --prefix asdf)/libexec/asdf.sh" ] &&
-  . "$(brew --prefix asdf)/libexec/asdf.sh"
+export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
 # bun completions
 [ -s "/Users/gotoharuka/.bun/_bun" ] && source "/Users/gotoharuka/.bun/_bun"


### PR DESCRIPTION
kind使いたいので入れてみた。

corepackの指定やasdfがバージョンアップして書き方変わったのと、pnpmの設定はあれcurlとかでインストールした時に必要な設定っぽくて別にasdfで入れるなら必要なさそうなので削除した